### PR TITLE
Fix broken delete method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -262,14 +262,22 @@ module.exports = Request;
 	Request[k] = function() {
 		var args = Array.prototype.slice.call(arguments);
 		if (_.isObject(args[0])) {
-			args[0].method = k;
+			args[0].method = _translateMethod(k);
 		}
 		else {
-			args[0] = {url:args[0], method: k};
+			args[0] = {url:args[0], method: _translateMethod(k)};
 		}
 		return Request.apply(null, args);
 	};
 });
+
+function _translateMethod(method) {
+	var m = method;
+	m = m.toUpperCase();
+	if(m === 'DEL') {
+		m = 'DELETE'; }
+	return m;
+};
 
 // these can just be patched
 ['forever','defaults','cookie','jar'].forEach(function(k){

--- a/lib/index.js
+++ b/lib/index.js
@@ -277,7 +277,7 @@ function _translateMethod(method) {
 	if(m === 'DEL') {
 		m = 'DELETE'; }
 	return m;
-};
+}
 
 // these can just be patched
 ['forever','defaults','cookie','jar'].forEach(function(k){


### PR DESCRIPTION
Currently the DELETE method is broken, and sends 'del' as the method to the request server. (the only method which the function for is different to the uppercase variant)

This PR transforms the method to uppercase allowing the correct method to be used.
